### PR TITLE
Remove extra backtics

### DIFF
--- a/manifests/rpm_gpg_key.pp
+++ b/manifests/rpm_gpg_key.pp
@@ -3,7 +3,7 @@ define epel::rpm_gpg_key($path) {
   exec {  "import-$name":
     path      => '/bin:/usr/bin:/sbin:/usr/sbin',
     command   => "rpm --import $path",
-    unless    => "rpm -q gpg-pubkey-`$(echo $(gpg --throw-keyids < $path) | cut --characters=11-18 | tr [A-Z] [a-z])`",
+    unless    => "rpm -q gpg-pubkey-$(echo $(gpg --throw-keyids < $path) | cut --characters=11-18 | tr [A-Z] [a-z])",
     require   => File[$path],
     logoutput => 'on_failure',
   }


### PR DESCRIPTION
There is a mix of backticks and $() in the unless which lead to a bug with an extra ) at the end.

```
debug: Exec[import-EPEL-6](provider=posix): Executing check 'rpm -q gpg-pubkey-`$(echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6) | cut --characters=11-18 | tr [A-Z] [a-z])`'
debug: Executing 'rpm -q gpg-pubkey-`$(echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6) | cut --characters=11-18 | tr [A-Z] [a-z])`'
debug: /Stage[main]/Epel/Epel::Rpm_gpg_key[EPEL-6]/Exec[import-EPEL-6]/unless: sh: 0608b895: command not found
debug: /Stage[main]/Epel/Epel::Rpm_gpg_key[EPEL-6]/Exec[import-EPEL-6]/unless: gpg-pubkey-c105b9de-4e0fd3a3
debug: /Stage[main]/Epel/Epel::Rpm_gpg_key[EPEL-6]/Exec[import-EPEL-6]/unless: gpg-pubkey-0608b895-4bd22942
```

Bash concurs:

```
[root@localhost ~]# rpm -q gpg-pubkey-`$(echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6) | cut --characters=11-18 | tr [A-Z] [a-z])`
-bash: 0608b895: command not found
gpg-pubkey-c105b9de-4e0fd3a3
gpg-pubkey-0608b895-4bd22942
```

Clearly the echo is working:

```
[root@localhost ~]# echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6) | cut --characters=11-18 | tr [A-Z] [a-z]
0608b895
```

The rpm query works as well given the key directly:

```
[root@localhost ~]# rpm -q gpg-pubkey-0608b895
gpg-pubkey-0608b895-4bd22942
```

It looks like you've got an extra ).

```
[root@localhost ~]# rpm -q gpg-pubkey-$(echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6) | cut --characters=11-18 | tr [A-Z] [a-z])
gpg-pubkey-0608b895-4bd22942
```
