### PR TITLE
Tr sets must be quoted

### DIFF
--- a/manifests/rpm_gpg_key.pp
+++ b/manifests/rpm_gpg_key.pp
@@ -3,7 +3,7 @@ define epel::rpm_gpg_key($path) {
   exec {  "import-$name":
     path      => '/bin:/usr/bin:/sbin:/usr/sbin',
     command   => "rpm --import $path",
-    unless    => "rpm -q gpg-pubkey-$(echo $(gpg --throw-keyids < $path) | cut --characters=11-18 | tr [A-Z] [a-z])",
+    unless    => "rpm -q gpg-pubkey-$(echo $(gpg --throw-keyids < $path) | cut --characters=11-18 | tr '[A-Z]' '[a-z]')",
     require   => File[$path],
     logoutput => 'on_failure',
   }


### PR DESCRIPTION
`Tr` sets (in square brackets) must be quoted. Otherwise the behaviour is unpredictable, e.g.:
### machine1:

```
echo 'ABCDEFGHIJKL' | tr [A-Z] [a-z]
aaaaaaaaaaaa
```
### machine2:

```
echo 'ABCDEFGHIJKL' | tr [A-Z] [a-z]
abcdefghijkl
```
