### PR TITLE
ensure :operatingsystemrelease value is not prematurely evaluated

### DIFF
--- a/lib/facter/os_maj_version.rb
+++ b/lib/facter/os_maj_version.rb
@@ -4,8 +4,8 @@
 # much of an issue.
 
 Facter.add(:os_maj_version) do
-  v = Facter.value(:operatingsystemrelease)
   setcode do
+    v = Facter.value(:operatingsystemrelease)
     v.split('.')[0].strip
   end
 end


### PR DESCRIPTION
Hi Michael. I was beating my head against a wall trying to figure out why :kernelrelease was being set in :operatingsystemrelease. The evaluation of :operatingsystemrelease in your fact is happening prematurely.

It'd be great if you could merge this change.

Thanks a bunch.
Tim
