### PR TITLE
Amazon Linux now recongnised as a valid distro for EPEL.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,7 @@
 #
 class epel inherits epel::params {
 
-  if $::osfamily == 'RedHat' and $::operatingsystem != 'Fedora' {
+  if $::osfamily == 'RedHat' and $::operatingsystem != 'Fedora' or $::osfamily == 'Linux' and $::operatingsystem == 'Amazon' {
 
     yumrepo { 'epel-testing':
       baseurl        => "http://download.fedora.redhat.com/pub/epel/testing/${::os_maj_version}/${::architecture}",


### PR DESCRIPTION
I found that that the init.pp didn't recognise Amazon Linux as a vaild distro for running EPEL, This should fix this.
