### PR TITLE
Allow proxy to be passed as a param

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,14 +9,14 @@
 # Sample Usage:
 #  include epel
 #
-class epel inherits epel::params {
+class epel ( $proxy = $epel::params::proxy ) inherits epel::params {
 
   if $::osfamily == 'RedHat' and $::operatingsystem != 'Fedora' {
 
     yumrepo { 'epel-testing':
       baseurl        => "http://download.fedora.redhat.com/pub/epel/testing/${::os_maj_version}/${::architecture}",
       failovermethod => 'priority',
-      proxy          => $epel::params::proxy,
+      proxy          => $proxy,
       enabled        => '0',
       gpgcheck       => '1',
       gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
@@ -26,7 +26,7 @@ class epel inherits epel::params {
     yumrepo { 'epel-testing-debuginfo':
       baseurl        => "http://download.fedora.redhat.com/pub/epel/testing/${::os_maj_version}/${::architecture}/debug",
       failovermethod => 'priority',
-      proxy          => $epel::params::proxy,
+      proxy          => $proxy,
       enabled        => '0',
       gpgcheck       => '1',
       gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
@@ -36,7 +36,7 @@ class epel inherits epel::params {
     yumrepo { 'epel-testing-source':
       baseurl        => "http://download.fedora.redhat.com/pub/epel/testing/${::os_maj_version}/SRPMS",
       failovermethod => 'priority',
-      proxy          => $epel::params::proxy,
+      proxy          => $proxy,
       enabled        => '0',
       gpgcheck       => '1',
       gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
@@ -46,7 +46,7 @@ class epel inherits epel::params {
     yumrepo { 'epel':
       mirrorlist     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-${::os_maj_version}&arch=${::architecture}",
       failovermethod => 'priority',
-      proxy          => $epel::params::proxy,
+      proxy          => $proxy,
       enabled        => '1',
       gpgcheck       => '1',
       gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
@@ -56,7 +56,7 @@ class epel inherits epel::params {
     yumrepo { 'epel-debuginfo':
       mirrorlist     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-${::os_maj_version}&arch=${::architecture}",
       failovermethod => 'priority',
-      proxy          => $epel::params::proxy,
+      proxy          => $proxy,
       enabled        => '0',
       gpgcheck       => '1',
       gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
@@ -65,7 +65,7 @@ class epel inherits epel::params {
 
     yumrepo { 'epel-source':
       mirrorlist     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-${::os_maj_version}&arch=${::architecture}",
-      proxy          => $epel::params::proxy,
+      proxy          => $proxy,
       failovermethod => 'priority',
       enabled        => '0',
       gpgcheck       => '1',


### PR DESCRIPTION
This PR adds $proxy as a class param.
That way the proxy can either be passed directly to the class or can be set via Hiera.

The advantage is that the module no longer needs to be edited to use a proxy, thus allowing easier upgrades to the module.
