### PR TITLE
update repo base url to avoid 404

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@ class epel inherits epel::params {
   if $::osfamily == 'RedHat' and $::operatingsystem != 'Fedora' {
 
     yumrepo { 'epel-testing':
-      baseurl        => "http://download.fedora.redhat.com/pub/epel/testing/${::os_maj_version}/${::architecture}",
+      baseurl        => "http://download.fedoraproject.org/pub/epel/testing/${::os_maj_version}/${::architecture}",
       failovermethod => 'priority',
       proxy          => $epel::params::proxy,
       enabled        => '0',
@@ -24,7 +24,7 @@ class epel inherits epel::params {
     }
 
     yumrepo { 'epel-testing-debuginfo':
-      baseurl        => "http://download.fedora.redhat.com/pub/epel/testing/${::os_maj_version}/${::architecture}/debug",
+      baseurl        => "http://download.fedoraproject.org/pub/epel/testing/${::os_maj_version}/${::architecture}/debug",
       failovermethod => 'priority',
       proxy          => $epel::params::proxy,
       enabled        => '0',
@@ -34,7 +34,7 @@ class epel inherits epel::params {
     }
 
     yumrepo { 'epel-testing-source':
-      baseurl        => "http://download.fedora.redhat.com/pub/epel/testing/${::os_maj_version}/SRPMS",
+      baseurl        => "http://download.fedoraproject.org/pub/epel/testing/${::os_maj_version}/SRPMS",
       failovermethod => 'priority',
       proxy          => $epel::params::proxy,
       enabled        => '0',


### PR DESCRIPTION
https://lists.fedoraproject.org/pipermail/announce/2012-February/003040.html

"""
we have removed the download.fedora.redhat.com alias
from DNS. Please update any scripts, documentation, links or other
resources that used the old download.fedora.redhat.com.

You can use 'dl.fedoraproject.org' if you wish to refer to the primary
mirrors that are managed by the Fedora Project Infrastructure.

You can use 'download.fedoraproject.org' if you wish to use a
mirrormanager provided mirror that may be close to you via GeoIP,
netblock or ASN.
"""
