### PR TITLE
Parameterize repo values

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,68 +9,104 @@
 # Sample Usage:
 #  include epel
 #
-class epel ( $proxy = $epel::params::proxy ) inherits epel::params {
+class epel (
+  $epel_mirrorlist                        = $epel::params::epel_mirrorlist,
+  $epel_baseurl                           = $epel::params::epel_baseurl,
+  $epel_failovermethod                    = $epel::params::epel_failovermethod,
+  $epel_proxy                             = $epel::params::epel_proxy,
+  $epel_enabled                           = $epel::params::epel_enabled,
+  $epel_gpgcheck                          = $epel::params::epel_gpgcheck,
+  $epel_testing_baseurl                   = $epel::params::epel_testing_baseurl,
+  $epel_testing_failovermethod            = $epel::params::epel_testing_failovermethod,
+  $epel_testing_proxy                     = $epel::params::epel_testing_proxy,
+  $epel_testing_enabled                   = $epel::params::epel_testing_enabled,
+  $epel_testing_gpgcheck                  = $epel::params::epel_testing_gpgcheck,
+  $epel_source_mirrorlist                 = $epel::params::epel_source_mirrorlist,
+  $epel_source_baseurl                    = $epel::params::epel_source_baseurl,
+  $epel_source_failovermethod             = $epel::params::epel_source_failovermethod,
+  $epel_source_proxy                      = $epel::params::epel_source_proxy,
+  $epel_source_enabled                    = $epel::params::epel_source_enabled,
+  $epel_source_gpgcheck                   = $epel::params::epel_source_gpgcheck,
+  $epel_debuginfo_mirrorlist              = $epel::params::epel_debuginfo_mirrorlist,
+  $epel_debuginfo_baseurl                 = $epel::params::epel_debuginfo_baseurl,
+  $epel_debuginfo_failovermethod          = $epel::params::epel_debuginfo_failovermethod,
+  $epel_debuginfo_proxy                   = $epel::params::epel_debuginfo_proxy,
+  $epel_debuginfo_enabled                 = $epel::params::epel_debuginfo_enabled,
+  $epel_debuginfo_gpgcheck                = $epel::params::epel_debuginfo_gpgcheck,
+  $epel_testing_source_baseurl            = $epel::params::epel_testing_source_baseurl,
+  $epel_testing_source_failovermethod     = $epel::params::epel_testing_source_failovermethod,
+  $epel_testing_source_proxy              = $epel::params::epel_testing_source_proxy,
+  $epel_testing_source_enabled            = $epel::params::epel_testing_source_enabled,
+  $epel_testing_source_gpgcheck           = $epel::params::epel_testing_source_gpgcheck,
+  $epel_testing_debuginfo_baseurl         = $epel::params::epel_testing_debuginfo_baseurl,
+  $epel_testing_debuginfo_failovermethod  = $epel::params::epel_testing_debuginfo_failovermethod,
+  $epel_testing_debuginfo_proxy           = $epel::params::epel_testing_debuginfo_proxy,
+  $epel_testing_debuginfo_enabled         = $epel::params::epel_testing_debuginfo_enabled,
+  $epel_testing_debuginfo_gpgcheck        = $epel::params::epel_testing_debuginfo_gpgcheck
+) inherits epel::params {
 
   if $::osfamily == 'RedHat' and $::operatingsystem !~ /Fedora|Amazon/ {
-
     yumrepo { 'epel-testing':
-      baseurl        => "http://download.fedoraproject.org/pub/epel/testing/${::os_maj_version}/${::architecture}",
-      failovermethod => 'priority',
-      proxy          => $proxy,
-      enabled        => '0',
-      gpgcheck       => '1',
+      baseurl        => $epel_testing_baseurl,
+      failovermethod => $epel_testing_failovermethod,
+      proxy          => $epel_testing_proxy,
+      enabled        => $epel_testing_enabled,
+      gpgcheck       => $epel_testing_gpgcheck,
       gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
-      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - Testing - ${::architecture} "
+      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - Testing - ${::architecture} ",
     }
 
     yumrepo { 'epel-testing-debuginfo':
-      baseurl        => "http://download.fedoraproject.org/pub/epel/testing/${::os_maj_version}/${::architecture}/debug",
-      failovermethod => 'priority',
-      proxy          => $proxy,
-      enabled        => '0',
-      gpgcheck       => '1',
+      baseurl        => $epel_testing_debuginfo_baseurl,
+      failovermethod => $epel_testing_debuginfo_failovermethod,
+      proxy          => $epel_testing_debuginfo_proxy,
+      enabled        => $epel_testing_debuginfo_enabled,
+      gpgcheck       => $epel_testing_debuginfo_gpgcheck,
       gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
-      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - Testing - ${::architecture} - Debug"
+      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - Testing - ${::architecture} - Debug",
     }
 
     yumrepo { 'epel-testing-source':
-      baseurl        => "http://download.fedoraproject.org/pub/epel/testing/${::os_maj_version}/SRPMS",
-      failovermethod => 'priority',
-      proxy          => $proxy,
-      enabled        => '0',
-      gpgcheck       => '1',
+      baseurl        => $epel_testing_source_baseurl,
+      failovermethod => $epel_testing_source_failovermethod,
+      proxy          => $epel_testing_source_proxy,
+      enabled        => $epel_testing_source_enabled,
+      gpgcheck       => $epel_testing_source_gpgcheck,
       gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
-      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - Testing - ${::architecture} - Source"
+      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - Testing - ${::architecture} - Source",
     }
 
     yumrepo { 'epel':
-      mirrorlist     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-${::os_maj_version}&arch=${::architecture}",
-      failovermethod => 'priority',
-      proxy          => $proxy,
-      enabled        => '1',
-      gpgcheck       => '1',
+      mirrorlist     => $epel_mirrorlist,
+      baseurl        => $epel_baseurl,
+      failovermethod => $epel_failovermethod,
+      proxy          => $epel_proxy,
+      enabled        => $epel_enabled,
+      gpgcheck       => $epel_gpgcheck,
       gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
-      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - ${::architecture}"
+      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - ${::architecture}",
     }
 
     yumrepo { 'epel-debuginfo':
-      mirrorlist     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-${::os_maj_version}&arch=${::architecture}",
-      failovermethod => 'priority',
-      proxy          => $proxy,
-      enabled        => '0',
-      gpgcheck       => '1',
+      mirrorlist     => $epel_debuginfo_mirrorlist,
+      baseurl        => $epel_debuginfo_baseurl,
+      failovermethod => $epel_debuginfo_failovermethod,
+      proxy          => $epel_debuginfo_proxy,
+      enabled        => $epel_debuginfo_enabled,
+      gpgcheck       => $epel_debuginfo_gpgcheck,
       gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
-      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - ${::architecture} - Debug"
+      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - ${::architecture} - Debug",
     }
 
     yumrepo { 'epel-source':
-      mirrorlist     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-${::os_maj_version}&arch=${::architecture}",
-      proxy          => $proxy,
-      failovermethod => 'priority',
-      enabled        => '0',
-      gpgcheck       => '1',
+      mirrorlist     => $epel_source_mirrorlist,
+      baseurl        => $epel_source_baseurl,
+      failovermethod => $epel_source_failovermethod,
+      proxy          => $epel_source_proxy,
+      enabled        => $epel_source_enabled,
+      gpgcheck       => $epel_source_gpgcheck,
       gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
-      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - ${::architecture} - Source"
+      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - ${::architecture} - Source",
     }
 
     file { "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}":
@@ -82,22 +118,17 @@ class epel ( $proxy = $epel::params::proxy ) inherits epel::params {
     }
 
     epel::rpm_gpg_key{ "EPEL-${::os_maj_version}":
-      path   => "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
-      before => Yumrepo['epel','epel-source','epel-debuginfo','epel-testing','epel-testing-source','epel-testing-debuginfo'],
+      path    => "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
+      before  => Yumrepo['epel','epel-source','epel-debuginfo','epel-testing','epel-testing-source','epel-testing-debuginfo'],
     }
 
   } elsif $::osfamily == 'RedHat' and $::operatingsystem == 'Amazon' {
-
-    # EPEL is already installed in all AWS Linux AMI
-    # we just need to enable it
     yumrepo { 'epel':
-      enabled  => 1,
-      gpgcheck => 1,
-
+      enabled   => $epel_enabled,
+      gpgcheck  => $epel_gpgcheck,
     }
-
   } else {
-      notice ("Your operating system ${::operatingsystem} will not have the EPEL repository applied")
+    notice ("Your operating system ${::operatingsystem} will not have the EPEL repository applied")
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,4 +7,39 @@ class epel::params {
   #   you can declare $proxy in that class, and should scope to
   #   the most specific declaration of proxy.
   $proxy = 'absent'
+
+  $epel_mirrorlist                        = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-${::os_maj_version}&arch=${::architecture}"
+  $epel_baseurl                           = 'absent'
+  $epel_failovermethod                    = 'priority'
+  $epel_proxy                             = $proxy
+  $epel_enabled                           = '1'
+  $epel_gpgcheck                          = '1'
+  $epel_testing_baseurl                   = "http://download.fedoraproject.org/pub/epel/testing/${::os_maj_version}/${::architecture}"
+  $epel_testing_failovermethod            = 'priority'
+  $epel_testing_proxy                     = $proxy
+  $epel_testing_enabled                   = '0'
+  $epel_testing_gpgcheck                  = '1'
+  $epel_source_mirrorlist                 = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-${::os_maj_version}&arch=${::architecture}"
+  $epel_source_baseurl                    = 'absent'
+  $epel_source_failovermethod             = 'priority'
+  $epel_source_proxy                      = $proxy
+  $epel_source_enabled                    = '0'
+  $epel_source_gpgcheck                   = '1'
+  $epel_debuginfo_mirrorlist              = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-${::os_maj_version}&arch=${::architecture}"
+  $epel_debuginfo_baseurl                 = 'absent'
+  $epel_debuginfo_failovermethod          = 'priority'
+  $epel_debuginfo_proxy                   = $proxy
+  $epel_debuginfo_enabled                 = '0'
+  $epel_debuginfo_gpgcheck                = '1'
+  $epel_testing_source_baseurl            = "http://download.fedoraproject.org/pub/epel/testing/${::os_maj_version}/SRPMS"
+  $epel_testing_source_failovermethod     = 'priority'
+  $epel_testing_source_proxy              = $proxy
+  $epel_testing_source_enabled            = '0'
+  $epel_testing_source_gpgcheck           = '1'
+  $epel_testing_debuginfo_baseurl         = "http://download.fedoraproject.org/pub/epel/testing/${::os_maj_version}/${::architecture}/debug"
+  $epel_testing_debuginfo_failovermethod  = 'priority'
+  $epel_testing_debuginfo_proxy           = $proxy
+  $epel_testing_debuginfo_enabled         = '0'
+  $epel_testing_debuginfo_gpgcheck        = '1'
+
 }

--- a/spec/classes/epel_spec.rb
+++ b/spec/classes/epel_spec.rb
@@ -27,6 +27,16 @@ describe 'epel' do
           :os_maj_version         => '6',
         })
       end
+
+      context 'epel_baseurl => http://example.com/epel/6/x86_64' do
+        let(:params) {{ :epel_baseurl => "http://example.com/epel/6/x86_64" }}
+        it { should contain_yumrepo('epel').with('baseurl'  => 'http://example.com/epel/6/x86_64') }
+      end
+      
+      context 'epel_mirrorlist => absent' do
+        let(:params) {{ :epel_mirrorlist => 'absent' }}
+        it { should contain_yumrepo('epel').with('mirrorlist'  => 'absent') }
+      end
     end
 
     context 'os_maj_version => 5' do

--- a/spec/system/basic_spec.rb
+++ b/spec/system/basic_spec.rb
@@ -28,9 +28,7 @@ describe 'epel class:' do
 
     # Only test for EPEL's presence if not Fedora
     if facts['operatingsystem'] !~ /Fedora/
-      context shell 'yum clean all && yum repolist enabled | grep -c epel' do
-        its(:stdout) { should_not =~ /0/ }
-        its(:stderr) { should be_empty }
+      context shell '/usr/bin/yum-config-manager epel | grep -q "\[epel\]"' do
         its(:exit_code) { should be_zero }
       end
     end

--- a/spec/system/usage_spec.rb
+++ b/spec/system/usage_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper_system'
+
+describe 'standage usage tests:' do
+  context 'test epel baseurl and mirrorlist' do
+    facts = node.facts
+    os_maj_version = facts['operatingsystemrelease'].split('.')[0]
+    pp = <<-EOS
+      class { 'epel':
+        epel_baseurl    => 'http://dl.fedoraproject.org/pub/epel/#{os_maj_version}/x86_64/',
+        epel_mirrorlist => 'absent',
+      }
+    EOS
+
+    context puppet_apply pp do
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should_not == 1 }
+      its(:refresh) { should be_nil }
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should be_zero }
+    end
+
+    # Only test for EPEL's presence if not Fedora
+    if facts['operatingsystem'] !~ /Fedora/
+      # Test the yum config to ensure mirrorlist was emptied
+      context shell '/usr/bin/yum-config-manager epel | egrep "^mirrorlist ="' do
+        its(:stdout) { should =~ /mirrorlist =\s+/ }
+      end
+
+      # Test the yum config to ensure baseurl was defined
+      context shell '/usr/bin/yum-config-manager epel | egrep "^baseurl ="' do
+        its(:stdout) { should =~ /baseurl = http:\/\/dl.fedoraproject.org\/pub\/epel\/#{os_maj_version}\/x86_64\// }
+      end
+    end
+  end
+
+  context 'test epel-testing is enabled' do
+    facts = node.facts
+    pp = <<-EOS
+      class { 'epel':
+        epel_testing_enabled    => '1',
+      }
+    EOS
+
+    context puppet_apply pp do
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should_not == 1 }
+      its(:refresh) { should be_nil }
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should be_zero }
+    end
+
+    # Only test for EPEL's presence if not Fedora
+    if facts['operatingsystem'] !~ /Fedora/
+      # Test the yum config to ensure epel-testing was enabled
+      context shell '/usr/bin/yum-config-manager epel-testing | grep -q "enabled = True"' do
+        its(:exit_code) { should be_zero }
+      end
+    end
+  end
+end


### PR DESCRIPTION
The rspec-puppet and rspec-system-puppet PRs have lead to these changes, which should be backwards compatible.

One use case in particular is to allow changing of baseurl and disabling mirrorlist so internal repos can be used.
