### PR TITLE
Change $::architecture to \$basearch

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,7 +53,7 @@ class epel (
       enabled        => $epel_testing_enabled,
       gpgcheck       => $epel_testing_gpgcheck,
       gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
-      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - Testing - ${::architecture} ",
+      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - Testing - \$basearch ",
     }
 
     yumrepo { 'epel-testing-debuginfo':
@@ -63,7 +63,7 @@ class epel (
       enabled        => $epel_testing_debuginfo_enabled,
       gpgcheck       => $epel_testing_debuginfo_gpgcheck,
       gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
-      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - Testing - ${::architecture} - Debug",
+      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - Testing - \$basearch - Debug",
     }
 
     yumrepo { 'epel-testing-source':
@@ -73,7 +73,7 @@ class epel (
       enabled        => $epel_testing_source_enabled,
       gpgcheck       => $epel_testing_source_gpgcheck,
       gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
-      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - Testing - ${::architecture} - Source",
+      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - Testing - \$basearch - Source",
     }
 
     yumrepo { 'epel':
@@ -84,7 +84,7 @@ class epel (
       enabled        => $epel_enabled,
       gpgcheck       => $epel_gpgcheck,
       gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
-      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - ${::architecture}",
+      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - \$basearch",
     }
 
     yumrepo { 'epel-debuginfo':
@@ -95,7 +95,7 @@ class epel (
       enabled        => $epel_debuginfo_enabled,
       gpgcheck       => $epel_debuginfo_gpgcheck,
       gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
-      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - ${::architecture} - Debug",
+      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - \$basearch - Debug",
     }
 
     yumrepo { 'epel-source':
@@ -106,7 +106,7 @@ class epel (
       enabled        => $epel_source_enabled,
       gpgcheck       => $epel_source_gpgcheck,
       gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
-      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - ${::architecture} - Source",
+      descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - \$basearch - Source",
     }
 
     file { "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}":

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,24 +8,24 @@ class epel::params {
   #   the most specific declaration of proxy.
   $proxy = 'absent'
 
-  $epel_mirrorlist                        = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-${::os_maj_version}&arch=${::architecture}"
+  $epel_mirrorlist                        = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-${::os_maj_version}&arch=\$basearch"
   $epel_baseurl                           = 'absent'
   $epel_failovermethod                    = 'priority'
   $epel_proxy                             = $proxy
   $epel_enabled                           = '1'
   $epel_gpgcheck                          = '1'
-  $epel_testing_baseurl                   = "http://download.fedoraproject.org/pub/epel/testing/${::os_maj_version}/${::architecture}"
+  $epel_testing_baseurl                   = "http://download.fedoraproject.org/pub/epel/testing/${::os_maj_version}/\$basearch"
   $epel_testing_failovermethod            = 'priority'
   $epel_testing_proxy                     = $proxy
   $epel_testing_enabled                   = '0'
   $epel_testing_gpgcheck                  = '1'
-  $epel_source_mirrorlist                 = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-${::os_maj_version}&arch=${::architecture}"
+  $epel_source_mirrorlist                 = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-${::os_maj_version}&arch=\$basearch"
   $epel_source_baseurl                    = 'absent'
   $epel_source_failovermethod             = 'priority'
   $epel_source_proxy                      = $proxy
   $epel_source_enabled                    = '0'
   $epel_source_gpgcheck                   = '1'
-  $epel_debuginfo_mirrorlist              = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-${::os_maj_version}&arch=${::architecture}"
+  $epel_debuginfo_mirrorlist              = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-${::os_maj_version}&arch=\$basearch"
   $epel_debuginfo_baseurl                 = 'absent'
   $epel_debuginfo_failovermethod          = 'priority'
   $epel_debuginfo_proxy                   = $proxy
@@ -36,7 +36,7 @@ class epel::params {
   $epel_testing_source_proxy              = $proxy
   $epel_testing_source_enabled            = '0'
   $epel_testing_source_gpgcheck           = '1'
-  $epel_testing_debuginfo_baseurl         = "http://download.fedoraproject.org/pub/epel/testing/${::os_maj_version}/${::architecture}/debug"
+  $epel_testing_debuginfo_baseurl         = "http://download.fedoraproject.org/pub/epel/testing/${::os_maj_version}/\$basearch/debug"
   $epel_testing_debuginfo_failovermethod  = 'priority'
   $epel_testing_debuginfo_proxy           = $proxy
   $epel_testing_debuginfo_enabled         = '0'

--- a/spec/classes/shared_base.rb
+++ b/spec/classes/shared_base.rb
@@ -16,9 +16,9 @@ shared_context :base_6 do
 
   it do
     should contain_yumrepo('epel').with({
-      'mirrorlist'     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=#{facts[:architecture]}",
+      'mirrorlist'     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=$basearch",
       'gpgkey'         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6",
-      'descr'          => "Extra Packages for Enterprise Linux 6 - #{facts[:architecture]}",
+      'descr'          => "Extra Packages for Enterprise Linux 6 - $basearch",
     })
   end
 end
@@ -28,9 +28,9 @@ shared_context :base_5 do
 
   it do
     should contain_yumrepo('epel').with({
-      'mirrorlist'     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-5&arch=#{facts[:architecture]}",
+      'mirrorlist'     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-5&arch=$basearch",
       'gpgkey'         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-5",
-      'descr'          => "Extra Packages for Enterprise Linux 5 - #{facts[:architecture]}",
+      'descr'          => "Extra Packages for Enterprise Linux 5 - $basearch",
     })
   end
 end

--- a/spec/classes/shared_debuginfo.rb
+++ b/spec/classes/shared_debuginfo.rb
@@ -16,9 +16,9 @@ shared_context :epel_debuginfo_6 do
 
   it do
     should contain_yumrepo('epel-debuginfo').with({
-      'mirrorlist'     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-6&arch=#{facts[:architecture]}",
+      'mirrorlist'     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-6&arch=$basearch",
       'gpgkey'         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6",
-      'descr'          => "Extra Packages for Enterprise Linux 6 - #{facts[:architecture]} - Debug",
+      'descr'          => "Extra Packages for Enterprise Linux 6 - $basearch - Debug",
     })
   end
 end
@@ -28,9 +28,9 @@ shared_context :epel_debuginfo_5 do
 
   it do
     should contain_yumrepo('epel-debuginfo').with({
-      'mirrorlist'     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-5&arch=#{facts[:architecture]}",
+      'mirrorlist'     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-5&arch=$basearch",
       'gpgkey'         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-5",
-      'descr'          => "Extra Packages for Enterprise Linux 5 - #{facts[:architecture]} - Debug",
+      'descr'          => "Extra Packages for Enterprise Linux 5 - $basearch - Debug",
     })
   end
 end

--- a/spec/classes/shared_source.rb
+++ b/spec/classes/shared_source.rb
@@ -16,9 +16,9 @@ shared_context :epel_source_6 do
 
   it do
     should contain_yumrepo('epel-source').with({
-      'mirrorlist'     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-6&arch=#{facts[:architecture]}",
+      'mirrorlist'     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-6&arch=$basearch",
       'gpgkey'         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6",
-      'descr'          => "Extra Packages for Enterprise Linux 6 - #{facts[:architecture]} - Source",
+      'descr'          => "Extra Packages for Enterprise Linux 6 - $basearch - Source",
     })
   end
 end
@@ -28,9 +28,9 @@ shared_context :epel_source_5 do
 
   it do
     should contain_yumrepo('epel-source').with({
-      'mirrorlist'     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-5&arch=#{facts[:architecture]}",
+      'mirrorlist'     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-5&arch=$basearch",
       'gpgkey'         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-5",
-      'descr'          => "Extra Packages for Enterprise Linux 5 - #{facts[:architecture]} - Source",
+      'descr'          => "Extra Packages for Enterprise Linux 5 - $basearch - Source",
     })
   end
 end

--- a/spec/classes/shared_testing.rb
+++ b/spec/classes/shared_testing.rb
@@ -16,9 +16,9 @@ shared_context :epel_testing_6 do
 
   it do
     should contain_yumrepo('epel-testing').with({
-      'baseurl'        => "http://download.fedoraproject.org/pub/epel/testing/6/#{facts[:architecture]}",
+      'baseurl'        => "http://download.fedoraproject.org/pub/epel/testing/6/$basearch",
       'gpgkey'         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6",
-      'descr'          => "Extra Packages for Enterprise Linux 6 - Testing - #{facts[:architecture]} ",
+      'descr'          => "Extra Packages for Enterprise Linux 6 - Testing - $basearch ",
     })
   end
 end
@@ -28,9 +28,9 @@ shared_context :epel_testing_5 do
 
   it do
     should contain_yumrepo('epel-testing').with({
-      'baseurl'        => "http://download.fedoraproject.org/pub/epel/testing/5/#{facts[:architecture]}",
+      'baseurl'        => "http://download.fedoraproject.org/pub/epel/testing/5/$basearch",
       'gpgkey'         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-5",
-      'descr'          => "Extra Packages for Enterprise Linux 5 - Testing - #{facts[:architecture]} ",
+      'descr'          => "Extra Packages for Enterprise Linux 5 - Testing - $basearch ",
     })
   end
 end

--- a/spec/classes/shared_testing_debuginfo.rb
+++ b/spec/classes/shared_testing_debuginfo.rb
@@ -16,9 +16,9 @@ shared_context :epel_testing_debuginfo_6 do
 
   it do
     should contain_yumrepo('epel-testing-debuginfo').with({
-      'baseurl'        => "http://download.fedoraproject.org/pub/epel/testing/6/#{facts[:architecture]}/debug",
+      'baseurl'        => "http://download.fedoraproject.org/pub/epel/testing/6/$basearch/debug",
       'gpgkey'         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6",
-      'descr'          => "Extra Packages for Enterprise Linux 6 - Testing - #{facts[:architecture]} - Debug",
+      'descr'          => "Extra Packages for Enterprise Linux 6 - Testing - $basearch - Debug",
     })
   end
 end
@@ -28,9 +28,9 @@ shared_context :epel_testing_debuginfo_5 do
 
   it do
     should contain_yumrepo('epel-testing-debuginfo').with({
-      'baseurl'        => "http://download.fedoraproject.org/pub/epel/testing/5/#{facts[:architecture]}/debug",
+      'baseurl'        => "http://download.fedoraproject.org/pub/epel/testing/5/$basearch/debug",
       'gpgkey'         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-5",
-      'descr'          => "Extra Packages for Enterprise Linux 5 - Testing - #{facts[:architecture]} - Debug",
+      'descr'          => "Extra Packages for Enterprise Linux 5 - Testing - $basearch - Debug",
     })
   end
 end

--- a/spec/classes/shared_testing_source.rb
+++ b/spec/classes/shared_testing_source.rb
@@ -18,7 +18,7 @@ shared_context :epel_testing_source_6 do
     should contain_yumrepo('epel-testing-source').with({
       'baseurl'        => "http://download.fedoraproject.org/pub/epel/testing/6/SRPMS",
       'gpgkey'         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6",
-      'descr'          => "Extra Packages for Enterprise Linux 6 - Testing - #{facts[:architecture]} - Source",
+      'descr'          => "Extra Packages for Enterprise Linux 6 - Testing - $basearch - Source",
     })
   end
 end
@@ -30,7 +30,7 @@ shared_context :epel_testing_source_5 do
     should contain_yumrepo('epel-testing-source').with({
       'baseurl'        => "http://download.fedoraproject.org/pub/epel/testing/5/SRPMS",
       'gpgkey'         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-5",
-      'descr'          => "Extra Packages for Enterprise Linux 5 - Testing - #{facts[:architecture]} - Source",
+      'descr'          => "Extra Packages for Enterprise Linux 5 - Testing - $basearch - Source",
     })
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,5 @@ def default_facts
   {
     :osfamily               => 'RedHat',
     :operatingsystem        => 'CentOS',
-    :architecture           => 'x86_64',
   }
 end


### PR DESCRIPTION
This should yield better match epel-release and keep rpm -qV happy.
