### PR TITLE
Resolve issue when operatingsystemmajrelease fact is not present

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ group :development, :test do
   gem 'rspec-puppet', :require => false
   gem 'puppetlabs_spec_helper', :require => false
   gem 'puppet-lint', :require => false
+  gem 'puppet-syntax', :require => false
   gem 'rspec-system-puppet', '~>2.0.0'
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
+require 'puppet-syntax/tasks/puppet-syntax'
 require 'rspec-system/rake_task'
 
 task :default do
@@ -7,11 +8,27 @@ task :default do
 end
 
 # Disable specific puppet-lint checks
-PuppetLint.configuration.send("disable_80chars")
-PuppetLint.configuration.send("disable_class_inherits_from_params_class")
+exclude_paths = [
+  "pkg/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+
+Rake::Task[:lint].clear
+PuppetLint::RakeTask.new :lint do |config|
+  config.ignore_paths = exclude_paths
+  config.fail_on_warnings = true
+  config.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
+  config.disable_checks = ['80chars', 'class_inherits_from_params_class']
+  #config.relative = true
+end
+PuppetLint.configuration.relative = true
+
+PuppetSyntax.exclude_paths = exclude_paths
 
 desc "Run rspec-puppet and puppet-lint tasks"
 task :ci => [
+  :syntax,
   :lint,
   :spec,
 ]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,7 +43,8 @@ class epel (
   $epel_testing_debuginfo_failovermethod  = $epel::params::epel_testing_debuginfo_failovermethod,
   $epel_testing_debuginfo_proxy           = $epel::params::epel_testing_debuginfo_proxy,
   $epel_testing_debuginfo_enabled         = $epel::params::epel_testing_debuginfo_enabled,
-  $epel_testing_debuginfo_gpgcheck        = $epel::params::epel_testing_debuginfo_gpgcheck
+  $epel_testing_debuginfo_gpgcheck        = $epel::params::epel_testing_debuginfo_gpgcheck,
+  $os_maj_release                         = $epel::params::os_maj_release,
 ) inherits epel::params {
 
   if $::osfamily == 'RedHat' and $::operatingsystem !~ /Fedora|Amazon/ {
@@ -53,8 +54,8 @@ class epel (
       proxy          => $epel_testing_proxy,
       enabled        => $epel_testing_enabled,
       gpgcheck       => $epel_testing_gpgcheck,
-      gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::operatingsystemmajrelease}",
-      descr          => "Extra Packages for Enterprise Linux ${::operatingsystemmajrelease} - Testing - \$basearch ",
+      gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${os_maj_release}",
+      descr          => "Extra Packages for Enterprise Linux ${os_maj_release} - Testing - \$basearch ",
     }
 
     yumrepo { 'epel-testing-debuginfo':
@@ -63,8 +64,8 @@ class epel (
       proxy          => $epel_testing_debuginfo_proxy,
       enabled        => $epel_testing_debuginfo_enabled,
       gpgcheck       => $epel_testing_debuginfo_gpgcheck,
-      gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::operatingsystemmajrelease}",
-      descr          => "Extra Packages for Enterprise Linux ${::operatingsystemmajrelease} - Testing - \$basearch - Debug",
+      gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${os_maj_release}",
+      descr          => "Extra Packages for Enterprise Linux ${os_maj_release} - Testing - \$basearch - Debug",
     }
 
     yumrepo { 'epel-testing-source':
@@ -73,8 +74,8 @@ class epel (
       proxy          => $epel_testing_source_proxy,
       enabled        => $epel_testing_source_enabled,
       gpgcheck       => $epel_testing_source_gpgcheck,
-      gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::operatingsystemmajrelease}",
-      descr          => "Extra Packages for Enterprise Linux ${::operatingsystemmajrelease} - Testing - \$basearch - Source",
+      gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${os_maj_release}",
+      descr          => "Extra Packages for Enterprise Linux ${os_maj_release} - Testing - \$basearch - Source",
     }
 
     yumrepo { 'epel':
@@ -84,8 +85,8 @@ class epel (
       proxy          => $epel_proxy,
       enabled        => $epel_enabled,
       gpgcheck       => $epel_gpgcheck,
-      gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::operatingsystemmajrelease}",
-      descr          => "Extra Packages for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
+      gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${os_maj_release}",
+      descr          => "Extra Packages for Enterprise Linux ${os_maj_release} - \$basearch",
     }
 
     yumrepo { 'epel-debuginfo':
@@ -95,8 +96,8 @@ class epel (
       proxy          => $epel_debuginfo_proxy,
       enabled        => $epel_debuginfo_enabled,
       gpgcheck       => $epel_debuginfo_gpgcheck,
-      gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::operatingsystemmajrelease}",
-      descr          => "Extra Packages for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - Debug",
+      gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${os_maj_release}",
+      descr          => "Extra Packages for Enterprise Linux ${os_maj_release} - \$basearch - Debug",
     }
 
     yumrepo { 'epel-source':
@@ -106,20 +107,20 @@ class epel (
       proxy          => $epel_source_proxy,
       enabled        => $epel_source_enabled,
       gpgcheck       => $epel_source_gpgcheck,
-      gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::operatingsystemmajrelease}",
-      descr          => "Extra Packages for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch - Source",
+      gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${os_maj_release}",
+      descr          => "Extra Packages for Enterprise Linux ${os_maj_release} - \$basearch - Source",
     }
 
-    file { "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::operatingsystemmajrelease}":
+    file { "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${os_maj_release}":
       ensure => present,
       owner  => 'root',
       group  => 'root',
       mode   => '0644',
-      source => "puppet:///modules/epel/RPM-GPG-KEY-EPEL-${::operatingsystemmajrelease}",
+      source => "puppet:///modules/epel/RPM-GPG-KEY-EPEL-${os_maj_release}",
     }
 
-    epel::rpm_gpg_key{ "EPEL-${::operatingsystemmajrelease}":
-      path   => "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::operatingsystemmajrelease}",
+    epel::rpm_gpg_key{ "EPEL-${os_maj_release}":
+      path   => "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${os_maj_release}",
       before => Yumrepo['epel','epel-source','epel-debuginfo','epel-testing','epel-testing-source','epel-testing-debuginfo'],
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,35 +8,42 @@ class epel::params {
   #   the most specific declaration of proxy.
   $proxy = 'absent'
 
-  $epel_mirrorlist                        = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-${::operatingsystemmajrelease}&arch=\$basearch"
+  if $::operatingsystemmajrelease {
+    $os_maj_release = $::operatingsystemmajrelease
+  } else {
+    $os_versions    = split($::operatingsystemrelease, '[.]')
+    $os_maj_release = $os_versions[0]
+  }
+
+  $epel_mirrorlist                        = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-${os_maj_release}&arch=\$basearch"
   $epel_baseurl                           = 'absent'
   $epel_failovermethod                    = 'priority'
   $epel_proxy                             = $proxy
   $epel_enabled                           = '1'
   $epel_gpgcheck                          = '1'
-  $epel_testing_baseurl                   = "http://download.fedoraproject.org/pub/epel/testing/${::operatingsystemmajrelease}/\$basearch"
+  $epel_testing_baseurl                   = "http://download.fedoraproject.org/pub/epel/testing/${os_maj_release}/\$basearch"
   $epel_testing_failovermethod            = 'priority'
   $epel_testing_proxy                     = $proxy
   $epel_testing_enabled                   = '0'
   $epel_testing_gpgcheck                  = '1'
-  $epel_source_mirrorlist                 = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-${::operatingsystemmajrelease}&arch=\$basearch"
+  $epel_source_mirrorlist                 = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-${os_maj_release}&arch=\$basearch"
   $epel_source_baseurl                    = 'absent'
   $epel_source_failovermethod             = 'priority'
   $epel_source_proxy                      = $proxy
   $epel_source_enabled                    = '0'
   $epel_source_gpgcheck                   = '1'
-  $epel_debuginfo_mirrorlist              = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-${::operatingsystemmajrelease}&arch=\$basearch"
+  $epel_debuginfo_mirrorlist              = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-${os_maj_release}&arch=\$basearch"
   $epel_debuginfo_baseurl                 = 'absent'
   $epel_debuginfo_failovermethod          = 'priority'
   $epel_debuginfo_proxy                   = $proxy
   $epel_debuginfo_enabled                 = '0'
   $epel_debuginfo_gpgcheck                = '1'
-  $epel_testing_source_baseurl            = "http://download.fedoraproject.org/pub/epel/testing/${::operatingsystemmajrelease}/SRPMS"
+  $epel_testing_source_baseurl            = "http://download.fedoraproject.org/pub/epel/testing/${os_maj_release}/SRPMS"
   $epel_testing_source_failovermethod     = 'priority'
   $epel_testing_source_proxy              = $proxy
   $epel_testing_source_enabled            = '0'
   $epel_testing_source_gpgcheck           = '1'
-  $epel_testing_debuginfo_baseurl         = "http://download.fedoraproject.org/pub/epel/testing/${::operatingsystemmajrelease}/\$basearch/debug"
+  $epel_testing_debuginfo_baseurl         = "http://download.fedoraproject.org/pub/epel/testing/${os_maj_release}/\$basearch/debug"
   $epel_testing_debuginfo_failovermethod  = 'priority'
   $epel_testing_debuginfo_proxy           = $proxy
   $epel_testing_debuginfo_enabled         = '0'

--- a/spec/classes/epel_spec.rb
+++ b/spec/classes/epel_spec.rb
@@ -12,21 +12,64 @@ describe 'epel' do
   it { should contain_class('epel::params') }
 
   context "operatingsystem => #{default_facts[:operatingsystem]}" do
-    context 'operatingsystemmajrelease => 6' do
-      include_context :base_6
-      include_context :gpgkey_6
-      include_context :epel_source_6
-      include_context :epel_debuginfo_6
-      include_context :epel_testing_6
-      include_context :epel_testing_source_6
-      include_context :epel_testing_debuginfo_6
-
+    context 'operatingsystemmajrelease => 7' do
       let :facts do
         default_facts.merge({
-          :operatingsystemrelease => '6.4',
-          :operatingsystemmajrelease         => '6',
+          :operatingsystemrelease     => '7.0.1406',
+          :operatingsystemmajrelease  => '7',
         })
       end
+
+      it_behaves_like :base_7
+      it_behaves_like :gpgkey_7
+      it_behaves_like :epel_source_7
+      it_behaves_like :epel_debuginfo_7
+      it_behaves_like :epel_testing_7
+      it_behaves_like :epel_testing_source_7
+      it_behaves_like :epel_testing_debuginfo_7
+
+      context 'epel_baseurl => http://example.com/epel/7/x87_74' do
+        let(:params) {{ :epel_baseurl => "http://example.com/epel/7/x87_74" }}
+        it { should contain_yumrepo('epel').with('baseurl'  => 'http://example.com/epel/7/x87_74') }
+      end
+      
+      context 'epel_mirrorlist => absent' do
+        let(:params) {{ :epel_mirrorlist => 'absent' }}
+        it { should contain_yumrepo('epel').with('mirrorlist'  => 'absent') }
+      end
+
+      context 'operatingsystemmajrelease undef' do
+        let :facts do
+          default_facts.merge({
+            :operatingsystemrelease => '7.0.1406',
+          })
+        end
+
+        it_behaves_like :base_7
+        it_behaves_like :gpgkey_7
+        it_behaves_like :epel_source_7
+        it_behaves_like :epel_debuginfo_7
+        it_behaves_like :epel_testing_7
+        it_behaves_like :epel_testing_source_7
+        it_behaves_like :epel_testing_debuginfo_7
+      end
+    end
+
+    context 'operatingsystemmajrelease => 6' do
+      let :facts do
+        default_facts.merge({
+          :operatingsystemrelease     => '6.4',
+          :operatingsystemmajrelease  => '6',
+        })
+      end
+
+      it_behaves_like :base_6
+      it_behaves_like :gpgkey_6
+      it_behaves_like :epel_source_6
+      it_behaves_like :epel_debuginfo_6
+      it_behaves_like :epel_testing_6
+      it_behaves_like :epel_testing_source_6
+      it_behaves_like :epel_testing_debuginfo_6
 
       context 'epel_baseurl => http://example.com/epel/6/x86_64' do
         let(:params) {{ :epel_baseurl => "http://example.com/epel/6/x86_64" }}
@@ -37,23 +80,39 @@ describe 'epel' do
         let(:params) {{ :epel_mirrorlist => 'absent' }}
         it { should contain_yumrepo('epel').with('mirrorlist'  => 'absent') }
       end
+
+      context 'operatingsystemmajrelease undef' do
+        let :facts do
+          default_facts.merge({
+            :operatingsystemrelease => '6.4',
+          })
+        end
+
+        it_behaves_like :base_6
+        it_behaves_like :gpgkey_6
+        it_behaves_like :epel_source_6
+        it_behaves_like :epel_debuginfo_6
+        it_behaves_like :epel_testing_6
+        it_behaves_like :epel_testing_source_6
+        it_behaves_like :epel_testing_debuginfo_6
+      end
     end
 
     context 'operatingsystemmajrelease => 5' do
-      include_context :base_5
-      include_context :gpgkey_5
-      include_context :epel_source_5
-      include_context :epel_debuginfo_5
-      include_context :epel_testing_5
-      include_context :epel_testing_source_5
-      include_context :epel_testing_debuginfo_5
-
       let :facts do
         default_facts.merge({
-          :operatingsystemrelease => '5.9',
-          :operatingsystemmajrelease         => '5',
+          :operatingsystemrelease     => '5.9',
+          :operatingsystemmajrelease  => '5',
         })
       end
+
+      it_behaves_like :base_5
+      it_behaves_like :gpgkey_5
+      it_behaves_like :epel_source_5
+      it_behaves_like :epel_debuginfo_5
+      it_behaves_like :epel_testing_5
+      it_behaves_like :epel_testing_source_5
+      it_behaves_like :epel_testing_debuginfo_5
     end
   end
 

--- a/spec/classes/shared_base.rb
+++ b/spec/classes/shared_base.rb
@@ -11,7 +11,19 @@ shared_context :base do
   end
 end
 
-shared_context :base_6 do
+shared_examples_for :base_7 do
+  include_context :base
+
+  it do
+    should contain_yumrepo('epel').with({
+      'mirrorlist'     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=$basearch",
+      'gpgkey'         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7",
+      'descr'          => "Extra Packages for Enterprise Linux 7 - $basearch",
+    })
+  end
+end
+
+shared_examples_for :base_6 do
   include_context :base
 
   it do
@@ -23,7 +35,7 @@ shared_context :base_6 do
   end
 end
 
-shared_context :base_5 do
+shared_examples_for :base_5 do
   include_context :base
 
   it do

--- a/spec/classes/shared_debuginfo.rb
+++ b/spec/classes/shared_debuginfo.rb
@@ -11,7 +11,19 @@ shared_context :epel_debuginfo do
   end
 end
 
-shared_context :epel_debuginfo_6 do
+shared_examples_for :epel_debuginfo_7 do
+  include_context :epel_debuginfo
+
+  it do
+    should contain_yumrepo('epel-debuginfo').with({
+      'mirrorlist'     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-7&arch=$basearch",
+      'gpgkey'         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7",
+      'descr'          => "Extra Packages for Enterprise Linux 7 - $basearch - Debug",
+    })
+  end
+end
+
+shared_examples_for :epel_debuginfo_6 do
   include_context :epel_debuginfo
 
   it do
@@ -23,7 +35,7 @@ shared_context :epel_debuginfo_6 do
   end
 end
 
-shared_context :epel_debuginfo_5 do
+shared_examples_for :epel_debuginfo_5 do
   include_context :epel_debuginfo
 
   it do

--- a/spec/classes/shared_gpgkey.rb
+++ b/spec/classes/shared_gpgkey.rb
@@ -1,6 +1,24 @@
 require 'spec_helper'
 
-shared_context :gpgkey_6 do
+shared_examples_for :gpgkey_7 do
+  it do
+    should contain_file("/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7").with({
+      'ensure' => 'present',
+      'owner'  => 'root',
+      'group'  => 'root',
+      'mode'   => '0644',
+      'source' => "puppet:///modules/epel/RPM-GPG-KEY-EPEL-7",
+    })
+  end
+
+  it do
+    should contain_epel__rpm_gpg_key("EPEL-7").with({
+      'path' => "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7"
+    })
+  end
+end
+
+shared_examples_for :gpgkey_6 do
   it do
     should contain_file("/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6").with({
       'ensure' => 'present',
@@ -18,7 +36,7 @@ shared_context :gpgkey_6 do
   end
 end
 
-shared_context :gpgkey_5 do
+shared_examples_for :gpgkey_5 do
   it do
     should contain_file("/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-5").with({
       'ensure' => 'present',

--- a/spec/classes/shared_source.rb
+++ b/spec/classes/shared_source.rb
@@ -11,7 +11,19 @@ shared_context :epel_source do
   end
 end
 
-shared_context :epel_source_6 do
+shared_examples_for :epel_source_7 do
+  include_context :epel_source
+
+  it do
+    should contain_yumrepo('epel-source').with({
+      'mirrorlist'     => "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-7&arch=$basearch",
+      'gpgkey'         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7",
+      'descr'          => "Extra Packages for Enterprise Linux 7 - $basearch - Source",
+    })
+  end
+end
+
+shared_examples_for :epel_source_6 do
   include_context :epel_source
 
   it do
@@ -23,7 +35,7 @@ shared_context :epel_source_6 do
   end
 end
 
-shared_context :epel_source_5 do
+shared_examples_for :epel_source_5 do
   include_context :epel_source
 
   it do

--- a/spec/classes/shared_testing.rb
+++ b/spec/classes/shared_testing.rb
@@ -11,7 +11,19 @@ shared_context :epel_testing do
   end
 end
 
-shared_context :epel_testing_6 do
+shared_examples_for :epel_testing_7 do
+  include_context :epel_testing
+
+  it do
+    should contain_yumrepo('epel-testing').with({
+      'baseurl'        => "http://download.fedoraproject.org/pub/epel/testing/7/$basearch",
+      'gpgkey'         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7",
+      'descr'          => "Extra Packages for Enterprise Linux 7 - Testing - $basearch ",
+    })
+  end
+end
+
+shared_examples_for :epel_testing_6 do
   include_context :epel_testing
 
   it do
@@ -23,7 +35,7 @@ shared_context :epel_testing_6 do
   end
 end
 
-shared_context :epel_testing_5 do
+shared_examples_for :epel_testing_5 do
   include_context :epel_testing
 
   it do

--- a/spec/classes/shared_testing_debuginfo.rb
+++ b/spec/classes/shared_testing_debuginfo.rb
@@ -11,7 +11,19 @@ shared_context :epel_testing_debuginfo do
   end
 end
 
-shared_context :epel_testing_debuginfo_6 do
+shared_examples_for :epel_testing_debuginfo_7 do
+  include_context :epel_testing_debuginfo
+
+  it do
+    should contain_yumrepo('epel-testing-debuginfo').with({
+      'baseurl'        => "http://download.fedoraproject.org/pub/epel/testing/7/$basearch/debug",
+      'gpgkey'         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7",
+      'descr'          => "Extra Packages for Enterprise Linux 7 - Testing - $basearch - Debug",
+    })
+  end
+end
+
+shared_examples_for :epel_testing_debuginfo_6 do
   include_context :epel_testing_debuginfo
 
   it do
@@ -23,7 +35,7 @@ shared_context :epel_testing_debuginfo_6 do
   end
 end
 
-shared_context :epel_testing_debuginfo_5 do
+shared_examples_for :epel_testing_debuginfo_5 do
   include_context :epel_testing_debuginfo
 
   it do

--- a/spec/classes/shared_testing_source.rb
+++ b/spec/classes/shared_testing_source.rb
@@ -11,7 +11,19 @@ shared_context :epel_testing_source do
   end
 end
 
-shared_context :epel_testing_source_6 do
+shared_examples_for :epel_testing_source_7 do
+  include_context :epel_testing_source
+
+  it do
+    should contain_yumrepo('epel-testing-source').with({
+      'baseurl'        => "http://download.fedoraproject.org/pub/epel/testing/7/SRPMS",
+      'gpgkey'         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7",
+      'descr'          => "Extra Packages for Enterprise Linux 7 - Testing - $basearch - Source",
+    })
+  end
+end
+
+shared_examples_for :epel_testing_source_6 do
   include_context :epel_testing_source
 
   it do
@@ -23,7 +35,7 @@ shared_context :epel_testing_source_6 do
   end
 end
 
-shared_context :epel_testing_source_5 do
+shared_examples_for :epel_testing_source_5 do
   include_context :epel_testing_source
 
   it do

--- a/spec/defines/rpm_gpg_key_spec.rb
+++ b/spec/defines/rpm_gpg_key_spec.rb
@@ -1,11 +1,38 @@
 require 'spec_helper'
 
 describe 'epel::rpm_gpg_key' do
+  context 'operatingsystemmajrelease => 7' do
+    let :facts do
+      default_facts.merge({
+        :operatingsystemrelease     => '7.0.1406',
+        :operatingsystemmajrelease  => '7',
+      })
+    end
+
+    let :title do
+      'EPEL-7'
+    end
+
+    let :params do
+      { :path => "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7" }
+    end
+
+    it do
+      should contain_exec("import-#{title}").with({
+        'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
+        'command'   => "rpm --import #{params[:path]}",
+        'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg --throw-keyids < #{params[:path]}) | cut --characters=11-18 | tr '[A-Z]' '[a-z]')",
+        'require'   => "File[#{params[:path]}]",
+        'logoutput' => 'on_failure',
+      })
+    end
+  end
+
   context 'operatingsystemmajrelease => 6' do
     let :facts do
       default_facts.merge({
-        :operatingsystemrelease => '6.4',
-        :operatingsystemmajrelease         => '6',
+        :operatingsystemrelease     => '6.4',
+        :operatingsystemmajrelease  => '6',
       })
     end
 
@@ -31,8 +58,8 @@ describe 'epel::rpm_gpg_key' do
   context 'operatingsystemmajrelease => 5' do
     let :facts do
       default_facts.merge({
-        :operatingsystemrelease => '5.9',
-        :operatingsystemmajrelease         => '5',
+        :operatingsystemrelease     => '5.9',
+        :operatingsystemmajrelease  => '5',
       })
     end
 


### PR DESCRIPTION
- Resolve issue when operatingsystemmajrelease fact is not present due to old version of Facter , issue #5
- Add os_maj_release parameter as way to set the value provided by operatingsystemmajrelease fact
- Use shared examples for unit tests to make reuse of the tests more clean
- Add puppet-syntax to unit tests
- Use lint rake task configuration for introduced puppet-lint 1.0
