### PR TITLE
Update rubocop to 0.49.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'puppet-lint-unquoted_string-check'
   gem 'metadata-json-lint'
   gem 'puppet-blacksmith'
-  gem 'rubocop', '0.48.0'
+  gem 'rubocop', '0.49.0'
   gem 'rubocop-rspec', '~> 1.15.0'
   gem 'simplecov-console'
 


### PR DESCRIPTION
This fixes a CVE - https://nvd.nist.gov/vuln/detail/CVE-2017-8418 - which GitHub reports.