### PR TITLE
Fix compilation on Fedora

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,7 +101,7 @@ class epel (
   Boolean $epel_gpg_managed               = true,
   $os_maj_release                         = $epel::params::os_maj_release,
 ) inherits epel::params {
-  if $facts['os']['family'] == 'RedHat' {
+  if $facts['os']['family'] == 'RedHat' and $facts['os']['name'] != 'Fedora' {
   if $epel_testing_managed {
     yumrepo { 'epel-testing':
       # lint:ignore:selector_inside_resource

--- a/spec/classes/epel_spec.rb
+++ b/spec/classes/epel_spec.rb
@@ -121,4 +121,31 @@ describe 'epel' do
       end
     end
   end
+  context 'on unsupported OSes' do
+    # On Fedora and other non RedHat systems, including `epel` is a no-op, but should still compile.
+    test_on = {
+      supported_os: [ # Unfortunate misnomer
+        {
+          'operatingsystem'        => 'Fedora',
+          'operatingsystemrelease' => %w[28 29 30]
+        },
+        {
+          'operatingsystem'        => 'Debian',
+          'operatingsystemrelease' => %w[8 9 10]
+        },
+        {
+          'operatingsystem'        => 'Ubuntu',
+          'operatingsystemrelease' => %w[16.04 18.04]
+        }
+      ]
+    }
+    on_supported_os(test_on).each do |os, os_facts|
+      context "on #{os}" do
+        let(:facts) { os_facts }
+
+        it { is_expected.to contain_class('epel') }
+        it { is_expected.to have_resource_count(0) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Prior to https://github.com/voxpupuli/puppet-epel/pull/95 including `epel` on
Fedora was a no-op. This commit restores this behaviour.