### PR TITLE
Remove failovermethod for 8 as option has been removed in DNF

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,9 +19,15 @@ class epel::params {
     $os_maj_release = $facts['os']['release']['major']
   }
 
+  if versioncmp($os_maj_release,'8') >= 0 {
+    $failovermethod = 'absent'
+  } else {
+    $failovermethod = 'priority'
+  }
+
   $epel_mirrorlist                        = "https://mirrors.fedoraproject.org/metalink?repo=epel-${os_maj_release}&arch=\$basearch"
   $epel_baseurl                           = 'absent'
-  $epel_failovermethod                    = 'priority'
+  $epel_failovermethod                    = $failovermethod
   $epel_proxy                             = $proxy
   $epel_enabled                           = '1'
   $epel_gpgcheck                          = '1'
@@ -29,7 +35,7 @@ class epel::params {
   $epel_metalink                          = "https://mirrors.fedoraproject.org/metalink?repo=epel-${os_maj_release}&arch=\$basearch"
   $epel_testing_mirrorlist                = "https://mirrors.fedoraproject.org/metalink?repo=testing-epel${os_maj_release}&arch=\$basearch"
   $epel_testing_baseurl                   = 'absent'
-  $epel_testing_failovermethod            = 'priority'
+  $epel_testing_failovermethod            = $failovermethod
   $epel_testing_proxy                     = $proxy
   $epel_testing_enabled                   = '0'
   $epel_testing_gpgcheck                  = '1'
@@ -37,7 +43,7 @@ class epel::params {
   $epel_testing_metalink                  = "https://mirrors.fedoraproject.org/metalink?repo=testing-epel${os_maj_release}&arch=\$basearch"
   $epel_source_mirrorlist                 = "https://mirrors.fedoraproject.org/metalink?repo=epel-source-${os_maj_release}&arch=\$basearch"
   $epel_source_baseurl                    = 'absent'
-  $epel_source_failovermethod             = 'priority'
+  $epel_source_failovermethod             = $failovermethod
   $epel_source_proxy                      = $proxy
   $epel_source_enabled                    = '0'
   $epel_source_gpgcheck                   = '1'
@@ -45,7 +51,7 @@ class epel::params {
   $epel_source_metalink                   = "https://mirrors.fedoraproject.org/metalink?repo=epel-source-${os_maj_release}&arch=\$basearch"
   $epel_debuginfo_mirrorlist              = "https://mirrors.fedoraproject.org/metalink?repo=epel-debug-${os_maj_release}&arch=\$basearch"
   $epel_debuginfo_baseurl                 = 'absent'
-  $epel_debuginfo_failovermethod          = 'priority'
+  $epel_debuginfo_failovermethod          = $failovermethod
   $epel_debuginfo_proxy                   = $proxy
   $epel_debuginfo_enabled                 = '0'
   $epel_debuginfo_gpgcheck                = '1'
@@ -53,7 +59,7 @@ class epel::params {
   $epel_debuginfo_metalink                = "https://mirrors.fedoraproject.org/metalink?repo=epel-debug-${os_maj_release}&arch=\$basearch"
   $epel_testing_source_mirrorlist         = "https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel${os_maj_release}&arch=\$basearch"
   $epel_testing_source_baseurl            = 'absent'
-  $epel_testing_source_failovermethod     = 'priority'
+  $epel_testing_source_failovermethod     = $failovermethod
   $epel_testing_source_proxy              = $proxy
   $epel_testing_source_enabled            = '0'
   $epel_testing_source_gpgcheck           = '1'
@@ -61,7 +67,7 @@ class epel::params {
   $epel_testing_source_metalink           = "https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel${os_maj_release}&arch=\$basearch"
   $epel_testing_debuginfo_mirrorlist      = "https://mirrors.fedoraproject.org/metalink?repo=testing-debug-epel${os_maj_release}&arch=\$basearch"
   $epel_testing_debuginfo_baseurl         = 'absent'
-  $epel_testing_debuginfo_failovermethod  = 'priority'
+  $epel_testing_debuginfo_failovermethod  = $failovermethod
   $epel_testing_debuginfo_proxy           = $proxy
   $epel_testing_debuginfo_enabled         = '0'
   $epel_testing_debuginfo_gpgcheck        = '1'

--- a/spec/classes/shared_base.rb
+++ b/spec/classes/shared_base.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 shared_examples :base do
   it do
     is_expected.to contain_yumrepo('epel').with(
-      failovermethod: 'priority',
       proxy:          'absent',
       enabled:        '1',
       gpgcheck:       '1',
@@ -17,9 +16,10 @@ shared_examples_for :base_8 do
 
   it do
     is_expected.to contain_yumrepo('epel').with(
-      mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch',
-      gpgkey:     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8',
-      descr:      'Extra Packages for Enterprise Linux 8 - $basearch'
+      mirrorlist:     'https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch',
+      gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8',
+      descr:          'Extra Packages for Enterprise Linux 8 - $basearch',
+      failovermethod: 'absent'
     )
   end
 end
@@ -29,9 +29,10 @@ shared_examples_for :base_7 do
 
   it do
     is_expected.to contain_yumrepo('epel').with(
-      mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch',
-      gpgkey:     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7',
-      descr:      'Extra Packages for Enterprise Linux 7 - $basearch'
+      mirrorlist:     'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch',
+      gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7',
+      descr:          'Extra Packages for Enterprise Linux 7 - $basearch',
+      failovermethod: 'priority'
     )
   end
 end
@@ -41,9 +42,10 @@ shared_examples_for :base_6 do
 
   it do
     is_expected.to contain_yumrepo('epel').with(
-      mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch',
-      gpgkey:     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6',
-      descr:      'Extra Packages for Enterprise Linux 6 - $basearch'
+      mirrorlist:     'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch',
+      gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6',
+      descr:          'Extra Packages for Enterprise Linux 6 - $basearch',
+      failovermethod: 'priority'
     )
   end
 end

--- a/spec/classes/shared_debuginfo.rb
+++ b/spec/classes/shared_debuginfo.rb
@@ -4,7 +4,6 @@ shared_examples :epel_debuginfo do
   it do
     is_expected.to contain_yumrepo('epel-debuginfo').with(
       proxy:          'absent',
-      failovermethod: 'priority',
       enabled:        '0',
       gpgcheck:       '1',
       repo_gpgcheck:  '0'
@@ -17,9 +16,10 @@ shared_examples_for :epel_debuginfo_8 do
 
   it do
     is_expected.to contain_yumrepo('epel-debuginfo').with(
-      mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-debug-8&arch=$basearch',
-      gpgkey:     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8',
-      descr:      'Extra Packages for Enterprise Linux 8 - $basearch - Debug'
+      mirrorlist:     'https://mirrors.fedoraproject.org/metalink?repo=epel-debug-8&arch=$basearch',
+      gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8',
+      descr:          'Extra Packages for Enterprise Linux 8 - $basearch - Debug',
+      failovermethod: 'absent'
     )
   end
 end
@@ -29,9 +29,10 @@ shared_examples_for :epel_debuginfo_7 do
 
   it do
     is_expected.to contain_yumrepo('epel-debuginfo').with(
-      mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-debug-7&arch=$basearch',
-      gpgkey:     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7',
-      descr:      'Extra Packages for Enterprise Linux 7 - $basearch - Debug'
+      mirrorlist:     'https://mirrors.fedoraproject.org/metalink?repo=epel-debug-7&arch=$basearch',
+      gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7',
+      descr:          'Extra Packages for Enterprise Linux 7 - $basearch - Debug',
+      failovermethod: 'priority'
     )
   end
 end
@@ -41,9 +42,10 @@ shared_examples_for :epel_debuginfo_6 do
 
   it do
     is_expected.to contain_yumrepo('epel-debuginfo').with(
-      mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-debug-6&arch=$basearch',
-      gpgkey:     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6',
-      descr:      'Extra Packages for Enterprise Linux 6 - $basearch - Debug'
+      mirrorlist:     'https://mirrors.fedoraproject.org/metalink?repo=epel-debug-6&arch=$basearch',
+      gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6',
+      descr:          'Extra Packages for Enterprise Linux 6 - $basearch - Debug',
+      failovermethod: 'priority'
     )
   end
 end

--- a/spec/classes/shared_source.rb
+++ b/spec/classes/shared_source.rb
@@ -4,7 +4,6 @@ shared_examples :epel_source do
   it do
     is_expected.to contain_yumrepo('epel-source').with(
       proxy:          'absent',
-      failovermethod: 'priority',
       enabled:        '0',
       gpgcheck:       '1',
       repo_gpgcheck:  '0'
@@ -17,9 +16,10 @@ shared_examples_for :epel_source_8 do
 
   it do
     is_expected.to contain_yumrepo('epel-source').with(
-      mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-source-8&arch=$basearch',
-      gpgkey:     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8',
-      descr:      'Extra Packages for Enterprise Linux 8 - $basearch - Source'
+      mirrorlist:     'https://mirrors.fedoraproject.org/metalink?repo=epel-source-8&arch=$basearch',
+      gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8',
+      descr:          'Extra Packages for Enterprise Linux 8 - $basearch - Source',
+      failovermethod: 'absent'
     )
   end
 end
@@ -29,9 +29,10 @@ shared_examples_for :epel_source_7 do
 
   it do
     is_expected.to contain_yumrepo('epel-source').with(
-      mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-source-7&arch=$basearch',
-      gpgkey:     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7',
-      descr:      'Extra Packages for Enterprise Linux 7 - $basearch - Source'
+      mirrorlist:     'https://mirrors.fedoraproject.org/metalink?repo=epel-source-7&arch=$basearch',
+      gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7',
+      descr:          'Extra Packages for Enterprise Linux 7 - $basearch - Source',
+      failovermethod: 'priority'
     )
   end
 end
@@ -41,9 +42,10 @@ shared_examples_for :epel_source_6 do
 
   it do
     is_expected.to contain_yumrepo('epel-source').with(
-      mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-source-6&arch=$basearch',
-      gpgkey:     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6',
-      descr:      'Extra Packages for Enterprise Linux 6 - $basearch - Source'
+      mirrorlist:     'https://mirrors.fedoraproject.org/metalink?repo=epel-source-6&arch=$basearch',
+      gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6',
+      descr:          'Extra Packages for Enterprise Linux 6 - $basearch - Source',
+      failovermethod: 'priority'
     )
   end
 end

--- a/spec/classes/shared_testing.rb
+++ b/spec/classes/shared_testing.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 shared_examples :epel_testing do
   it do
     is_expected.to contain_yumrepo('epel-testing').with(
-      failovermethod: 'priority',
       proxy:          'absent',
       enabled:        '0',
       gpgcheck:       '1',
@@ -17,9 +16,10 @@ shared_examples_for :epel_testing_8 do
 
   it do
     is_expected.to contain_yumrepo('epel-testing').with(
-      mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=testing-epel8&arch=$basearch',
-      gpgkey:     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8',
-      descr:      'Extra Packages for Enterprise Linux 8 - Testing - $basearch'
+      mirrorlist:     'https://mirrors.fedoraproject.org/metalink?repo=testing-epel8&arch=$basearch',
+      gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8',
+      descr:          'Extra Packages for Enterprise Linux 8 - Testing - $basearch',
+      failovermethod: 'absent'
     )
   end
 end
@@ -29,9 +29,10 @@ shared_examples_for :epel_testing_7 do
 
   it do
     is_expected.to contain_yumrepo('epel-testing').with(
-      mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=testing-epel7&arch=$basearch',
-      gpgkey:     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7',
-      descr:      'Extra Packages for Enterprise Linux 7 - Testing - $basearch'
+      mirrorlist:     'https://mirrors.fedoraproject.org/metalink?repo=testing-epel7&arch=$basearch',
+      gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7',
+      descr:          'Extra Packages for Enterprise Linux 7 - Testing - $basearch',
+      failovermethod: 'priority'
     )
   end
 end
@@ -41,9 +42,10 @@ shared_examples_for :epel_testing_6 do
 
   it do
     is_expected.to contain_yumrepo('epel-testing').with(
-      mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=testing-epel6&arch=$basearch',
-      gpgkey:     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6',
-      descr:      'Extra Packages for Enterprise Linux 6 - Testing - $basearch'
+      mirrorlist:     'https://mirrors.fedoraproject.org/metalink?repo=testing-epel6&arch=$basearch',
+      gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6',
+      descr:          'Extra Packages for Enterprise Linux 6 - Testing - $basearch',
+      failovermethod: 'priority'
     )
   end
 end

--- a/spec/classes/shared_testing_debuginfo.rb
+++ b/spec/classes/shared_testing_debuginfo.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 shared_examples :epel_testing_debuginfo do
   it do
     is_expected.to contain_yumrepo('epel-testing-debuginfo').with(
-      failovermethod: 'priority',
       proxy:          'absent',
       enabled:        '0',
       gpgcheck:       '1',
@@ -17,9 +16,10 @@ shared_examples_for :epel_testing_debuginfo_8 do
 
   it do
     is_expected.to contain_yumrepo('epel-testing-debuginfo').with(
-      mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=testing-debug-epel8&arch=$basearch',
-      gpgkey:     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8',
-      descr:      'Extra Packages for Enterprise Linux 8 - Testing - $basearch - Debug'
+      mirrorlist:     'https://mirrors.fedoraproject.org/metalink?repo=testing-debug-epel8&arch=$basearch',
+      gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8',
+      descr:          'Extra Packages for Enterprise Linux 8 - Testing - $basearch - Debug',
+      failovermethod: 'absent'
     )
   end
 end
@@ -29,9 +29,10 @@ shared_examples_for :epel_testing_debuginfo_7 do
 
   it do
     is_expected.to contain_yumrepo('epel-testing-debuginfo').with(
-      mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=testing-debug-epel7&arch=$basearch',
-      gpgkey:     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7',
-      descr:      'Extra Packages for Enterprise Linux 7 - Testing - $basearch - Debug'
+      mirrorlist:     'https://mirrors.fedoraproject.org/metalink?repo=testing-debug-epel7&arch=$basearch',
+      gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7',
+      descr:          'Extra Packages for Enterprise Linux 7 - Testing - $basearch - Debug',
+      failovermethod: 'priority'
     )
   end
 end
@@ -41,9 +42,10 @@ shared_examples_for :epel_testing_debuginfo_6 do
 
   it do
     is_expected.to contain_yumrepo('epel-testing-debuginfo').with(
-      mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=testing-debug-epel6&arch=$basearch',
-      gpgkey:     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6',
-      descr:      'Extra Packages for Enterprise Linux 6 - Testing - $basearch - Debug'
+      mirrorlist:     'https://mirrors.fedoraproject.org/metalink?repo=testing-debug-epel6&arch=$basearch',
+      gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6',
+      descr:          'Extra Packages for Enterprise Linux 6 - Testing - $basearch - Debug',
+      failovermethod: 'priority'
     )
   end
 end

--- a/spec/classes/shared_testing_source.rb
+++ b/spec/classes/shared_testing_source.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 shared_examples :epel_testing_source do
   it do
     is_expected.to contain_yumrepo('epel-testing-source').with(
-      failovermethod: 'priority',
       proxy:          'absent',
       enabled:        '0',
       gpgcheck:       '1',
@@ -17,9 +16,10 @@ shared_examples_for :epel_testing_source_8 do
 
   it do
     is_expected.to contain_yumrepo('epel-testing-source').with(
-      mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel8&arch=$basearch',
-      gpgkey:     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8',
-      descr:      'Extra Packages for Enterprise Linux 8 - Testing - $basearch - Source'
+      mirrorlist:     'https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel8&arch=$basearch',
+      gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8',
+      descr:          'Extra Packages for Enterprise Linux 8 - Testing - $basearch - Source',
+      failovermethod: 'absent'
     )
   end
 end
@@ -29,9 +29,10 @@ shared_examples_for :epel_testing_source_7 do
 
   it do
     is_expected.to contain_yumrepo('epel-testing-source').with(
-      mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel7&arch=$basearch',
-      gpgkey:     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7',
-      descr:      'Extra Packages for Enterprise Linux 7 - Testing - $basearch - Source'
+      mirrorlist:     'https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel7&arch=$basearch',
+      gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7',
+      descr:          'Extra Packages for Enterprise Linux 7 - Testing - $basearch - Source',
+      failovermethod: 'priority'
     )
   end
 end
@@ -41,9 +42,10 @@ shared_examples_for :epel_testing_source_6 do
 
   it do
     is_expected.to contain_yumrepo('epel-testing-source').with(
-      mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel6&arch=$basearch',
-      gpgkey:     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6',
-      descr:      'Extra Packages for Enterprise Linux 6 - Testing - $basearch - Source'
+      mirrorlist:     'https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel6&arch=$basearch',
+      gpgkey:         'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6',
+      descr:          'Extra Packages for Enterprise Linux 6 - Testing - $basearch - Source',
+      failovermethod: 'priority'
     )
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
Changes failovermethod to absent for RHEL 8 and derivatives so that this is removed from any EPEL repo definitions.

The failovermethod setting is not implemented in DNF as used in RHEL 8 and recent updates to the DNF package now flag the presence of this setting as an error.

#### This Pull Request (PR) fixes the following issues
Fixes #108 
